### PR TITLE
refactor task routes for idempotent enable/disable operations

### DIFF
--- a/http/handlers/scheduler_handlers.go
+++ b/http/handlers/scheduler_handlers.go
@@ -9,6 +9,9 @@ import (
 	// Local Packages
 	errors "scheduler/errors"
 	smodels "scheduler/models"
+
+	// External Packages
+	"github.com/go-chi/chi/v5"
 )
 
 type SchedulerService interface {
@@ -16,7 +19,8 @@ type SchedulerService interface {
 	GetActive(ctx context.Context) (*smodels.ActiveTasks, error)
 	Insert(ctx context.Context, taskQP smodels.TaskQP) (string, error)
 	Delete(ctx context.Context, taskID string) error
-	Toggle(ctx context.Context, taskID string) error
+	Enable(ctx context.Context, taskID string) error
+	Disable(ctx context.Context, taskID string) error
 	ExecuteNow(ctx context.Context, taskID string) error
 }
 
@@ -29,7 +33,7 @@ func NewSchedulerHandler(schedulerService SchedulerService) *SchedulerHandler {
 }
 
 func (h *SchedulerHandler) GetOne(w http.ResponseWriter, r *http.Request) (response any, status int, err error) {
-	taskID := r.URL.Query().Get("taskId")
+	taskID := chi.URLParam(r, "taskId")
 	if taskID == "" {
 		return nil, http.StatusBadRequest, errors.EmptyParamErr("taskId")
 	}
@@ -61,7 +65,7 @@ func (h *SchedulerHandler) Insert(w http.ResponseWriter, r *http.Request) (respo
 }
 
 func (h *SchedulerHandler) Delete(w http.ResponseWriter, r *http.Request) (response any, status int, err error) {
-	taskID := r.URL.Query().Get("taskId")
+	taskID := chi.URLParam(r, "taskId")
 	if taskID == "" {
 		return nil, http.StatusBadRequest, errors.EmptyParamErr("taskId")
 	}
@@ -76,16 +80,32 @@ func (h *SchedulerHandler) Delete(w http.ResponseWriter, r *http.Request) (respo
 	return
 }
 
-func (h *SchedulerHandler) Toggle(w http.ResponseWriter, r *http.Request) (response any, status int, err error) {
-	taskID := r.URL.Query().Get("taskId")
+func (h *SchedulerHandler) Enable(w http.ResponseWriter, r *http.Request) (response any, status int, err error) {
+	taskID := chi.URLParam(r, "taskId")
 	if taskID == "" {
 		return nil, http.StatusBadRequest, errors.EmptyParamErr("taskId")
 	}
 
-	err = h.schedulerService.Toggle(r.Context(), taskID)
+	err = h.schedulerService.Enable(r.Context(), taskID)
 	if err == nil {
 		return map[string]any{
-			"message": "Task Toggled Successfully",
+			"message": "Task Enabled Successfully",
+			"taskId":  taskID,
+		}, http.StatusOK, nil
+	}
+	return
+}
+
+func (h *SchedulerHandler) Disable(w http.ResponseWriter, r *http.Request) (response any, status int, err error) {
+	taskID := chi.URLParam(r, "taskId")
+	if taskID == "" {
+		return nil, http.StatusBadRequest, errors.EmptyParamErr("taskId")
+	}
+
+	err = h.schedulerService.Disable(r.Context(), taskID)
+	if err == nil {
+		return map[string]any{
+			"message": "Task Disabled Successfully",
 			"taskId":  taskID,
 		}, http.StatusOK, nil
 	}
@@ -101,7 +121,7 @@ func (h *SchedulerHandler) GetActive(w http.ResponseWriter, r *http.Request) (re
 }
 
 func (h *SchedulerHandler) Execute(w http.ResponseWriter, r *http.Request) (response any, status int, err error) {
-	taskID := r.URL.Query().Get("taskId")
+	taskID := chi.URLParam(r, "taskId")
 	if taskID == "" {
 		return nil, http.StatusBadRequest, errors.EmptyParamErr("taskId")
 	}

--- a/http/server.go
+++ b/http/server.go
@@ -57,15 +57,16 @@ func (s *Server) Listen(ctx context.Context, addr string) error {
 
 			r.Group(func(r chi.Router) {
 				r.Route("/task", func(r chi.Router) {
-					r.Get("/", s.ToHTTPHandlerFunc(s.scheduler.GetOne))
 					r.Post("/", s.ToHTTPHandlerFunc(s.scheduler.Insert))
-					r.Delete("/", s.ToHTTPHandlerFunc(s.scheduler.Delete))
-					r.Patch("/toggle", s.ToHTTPHandlerFunc(s.scheduler.Toggle))
+					r.Get("/{taskId}", s.ToHTTPHandlerFunc(s.scheduler.GetOne))
+					r.Delete("/{taskId}", s.ToHTTPHandlerFunc(s.scheduler.Delete))
+					r.Patch("/{taskId}/enable", s.ToHTTPHandlerFunc(s.scheduler.Enable))
+					r.Patch("/{taskId}/disable", s.ToHTTPHandlerFunc(s.scheduler.Disable))
 				})
 
 				r.Route("/helpers", func(r chi.Router) {
 					r.Get("/active-tasks", s.ToHTTPHandlerFunc(s.scheduler.GetActive))
-					r.Post("/execute-task", s.ToHTTPHandlerFunc(s.scheduler.Execute))
+					r.Post("/execute-task/{taskId}", s.ToHTTPHandlerFunc(s.scheduler.Execute))
 				})
 			})
 		})

--- a/http/server.go
+++ b/http/server.go
@@ -57,11 +57,12 @@ func (s *Server) Listen(ctx context.Context, addr string) error {
 
 			r.Group(func(r chi.Router) {
 				r.Route("/task", func(r chi.Router) {
-					r.Post("/", s.ToHTTPHandlerFunc(s.scheduler.Insert))
 					r.Get("/{taskId}", s.ToHTTPHandlerFunc(s.scheduler.GetOne))
-					r.Delete("/{taskId}", s.ToHTTPHandlerFunc(s.scheduler.Delete))
+					r.Post("/", s.ToHTTPHandlerFunc(s.scheduler.Insert))
 					r.Patch("/{taskId}/enable", s.ToHTTPHandlerFunc(s.scheduler.Enable))
 					r.Patch("/{taskId}/disable", s.ToHTTPHandlerFunc(s.scheduler.Disable))
+					r.Delete("/{taskId}", s.ToHTTPHandlerFunc(s.scheduler.Delete))
+
 				})
 
 				r.Route("/helpers", func(r chi.Router) {

--- a/http/server.go
+++ b/http/server.go
@@ -47,7 +47,6 @@ func NewServer(
 func (s *Server) Listen(ctx context.Context, addr string) error {
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
-	r.Use(middleware.RealIP)
 	r.Use(smiddleware.RequestLogger(s.logger))
 	r.Use(middleware.Recoverer)
 

--- a/services/scheduler/scheduler_service.go
+++ b/services/scheduler/scheduler_service.go
@@ -100,7 +100,7 @@ func (s *SchedulerService) Delete(ctx context.Context, taskID string) error {
 	return nil
 }
 
-func (s *SchedulerService) Toggle(ctx context.Context, taskID string) error {
+func (s *SchedulerService) Enable(ctx context.Context, taskID string) error {
 	task, err := s.schedulerRepo.GetOne(ctx, taskID)
 	if errors.Is(err, mongo.ErrNoDocuments) {
 		return errors.E(errors.NotFound, "task not found with given id")
@@ -109,17 +109,19 @@ func (s *SchedulerService) Toggle(ctx context.Context, taskID string) error {
 		return fmt.Errorf("failed to fetch task data: %w", err)
 	}
 
-	enable := !task.Enable
-	if err = s.schedulerRepo.UpdateEnable(ctx, taskID, enable); err != nil {
+	if task.Enable {
+		s.logger.Info("Task Is Already Enabled", zap.String("taskId", taskID))
+		return nil
+	}
+
+	if err = s.schedulerRepo.UpdateEnable(ctx, taskID, true); err != nil {
 		return fmt.Errorf("failed to update enable status: %w", err)
 	}
 
 	alreadyExecuted := task.Status.IsAlreadyExecuted()
 	if alreadyExecuted && !task.IsRecurEnabled {
-		if enable {
-			s.logger.Info("Non Recurring Task Already Executed, Skipping Reschedule",
-				zap.String("taskId", taskID))
-		}
+		s.logger.Info("Non Recurring Task Already Executed, Skipping Reschedule",
+			zap.String("taskId", taskID))
 		return nil
 	}
 
@@ -129,11 +131,29 @@ func (s *SchedulerService) Toggle(ctx context.Context, taskID string) error {
 		return nil
 	}
 
-	if enable {
-		s.ScheduleTask(task)
-	} else {
-		s.DiscardTaskNow(taskID)
+	s.ScheduleTask(task)
+	return nil
+}
+
+func (s *SchedulerService) Disable(ctx context.Context, taskID string) error {
+	task, err := s.schedulerRepo.GetOne(ctx, taskID)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return errors.E(errors.NotFound, "task not found with given id")
 	}
+	if err != nil {
+		return fmt.Errorf("failed to fetch task data: %w", err)
+	}
+
+	if !task.Enable {
+		s.logger.Info("Task Is Already Disabled", zap.String("taskId", taskID))
+		return nil
+	}
+
+	if err = s.schedulerRepo.UpdateEnable(ctx, taskID, false); err != nil {
+		return fmt.Errorf("failed to update enable status: %w", err)
+	}
+
+	s.DiscardTaskNow(taskID)
 	return nil
 }
 


### PR DESCRIPTION
- Split PATCH /task/toggle into PATCH /task/{taskId}/enable and /disable so each operation is idempotent and safe to retry on network failure
- Move taskId from query param to URL path param across all task routes
- Add execute-task/{taskId} path param for execute helper route