### PR TITLE
fix: resolve scheduler correctness issues and improve reliability

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -69,9 +69,13 @@ func LoadConfig() *koanf.Koanf {
 	kingpin.Parse()
 
 	k := koanf.New(".")
-	_ = k.Load(rawbytes.Provider(config.DefaultConfig), yaml.Parser())
+	if err := k.Load(rawbytes.Provider(config.DefaultConfig), yaml.Parser()); err != nil {
+		log.Fatalf("Failed to load default config: %v", err)
+	}
 	if *configPath != "" {
-		_ = k.Load(file.Provider(*configPath), yaml.Parser())
+		if err := k.Load(file.Provider(*configPath), yaml.Parser()); err != nil {
+			log.Fatalf("Failed to load config file %s: %v", *configPath, err)
+		}
 	}
 	return k
 }

--- a/repositories/mongodb/scheduler_repo.go
+++ b/repositories/mongodb/scheduler_repo.go
@@ -71,13 +71,16 @@ func (r *SchedulerRepository) Insert(ctx context.Context, task smodels.TaskModel
 	return err
 }
 
-func (r *SchedulerRepository) UpdateEnable(ctx context.Context, taskID string, enable bool) error {
+func (r *SchedulerRepository) UpdateEnable(ctx context.Context, taskID string, enable bool) (bool, error) {
 	collection := r.client.Database(r.database).Collection(r.collection)
-	filter := bson.M{"_id": taskID}
+	filter := bson.M{"_id": taskID, "enable": !enable}
 	currTime := helpers.GetCurrentDateTime()
 	updatedFields := bson.M{"$set": bson.M{"enable": enable, "updatedAt": currTime}}
-	_, err := collection.UpdateOne(ctx, filter, updatedFields)
-	return err
+	res, err := collection.UpdateOne(ctx, filter, updatedFields)
+	if err != nil {
+		return false, err
+	}
+	return res.MatchedCount > 0, nil
 }
 
 func (r *SchedulerRepository) Delete(ctx context.Context, taskID string) error {

--- a/services/scheduler/scheduler_service.go
+++ b/services/scheduler/scheduler_service.go
@@ -25,7 +25,7 @@ type SchedulerRepo interface {
 	GetActive(ctx context.Context, curUnix helpers.Unix) ([]smodels.TaskModel, error)
 	Insert(ctx context.Context, task smodels.TaskModel) error
 	UpdateTaskStatus(ctx context.Context, taskID, exceptionMsg string, isComplete bool) error
-	UpdateEnable(ctx context.Context, taskID string, enable bool) error
+	UpdateEnable(ctx context.Context, taskID string, enable bool) (bool, error)
 	Delete(ctx context.Context, taskID string) error
 }
 
@@ -109,13 +109,13 @@ func (s *SchedulerService) Enable(ctx context.Context, taskID string) error {
 		return fmt.Errorf("failed to fetch task data: %w", err)
 	}
 
-	if task.Enable {
+	updated, err := s.schedulerRepo.UpdateEnable(ctx, taskID, true)
+	if err != nil {
+		return fmt.Errorf("failed to update enable status: %w", err)
+	}
+	if !updated {
 		s.logger.Info("Task Is Already Enabled", zap.String("taskId", taskID))
 		return nil
-	}
-
-	if err = s.schedulerRepo.UpdateEnable(ctx, taskID, true); err != nil {
-		return fmt.Errorf("failed to update enable status: %w", err)
 	}
 
 	alreadyExecuted := task.Status.IsAlreadyExecuted()
@@ -136,7 +136,7 @@ func (s *SchedulerService) Enable(ctx context.Context, taskID string) error {
 }
 
 func (s *SchedulerService) Disable(ctx context.Context, taskID string) error {
-	task, err := s.schedulerRepo.GetOne(ctx, taskID)
+	_, err := s.schedulerRepo.GetOne(ctx, taskID)
 	if errors.Is(err, mongo.ErrNoDocuments) {
 		return errors.E(errors.NotFound, "task not found with given id")
 	}
@@ -144,13 +144,13 @@ func (s *SchedulerService) Disable(ctx context.Context, taskID string) error {
 		return fmt.Errorf("failed to fetch task data: %w", err)
 	}
 
-	if !task.Enable {
+	updated, err := s.schedulerRepo.UpdateEnable(ctx, taskID, false)
+	if err != nil {
+		return fmt.Errorf("failed to update enable status: %w", err)
+	}
+	if !updated {
 		s.logger.Info("Task Is Already Disabled", zap.String("taskId", taskID))
 		return nil
-	}
-
-	if err = s.schedulerRepo.UpdateEnable(ctx, taskID, false); err != nil {
-		return fmt.Errorf("failed to update enable status: %w", err)
 	}
 
 	s.DiscardTaskNow(taskID)
@@ -164,13 +164,6 @@ func (s *SchedulerService) ExecuteNow(ctx context.Context, taskID string) error 
 	}
 	if err != nil {
 		return fmt.Errorf("failed to fetch task data: %w", err)
-	}
-
-	alreadyExecuted := task.Status.IsAlreadyExecuted()
-	if alreadyExecuted && !task.IsRecurEnabled {
-		s.logger.Info("Non Recurring Task Already Executed",
-			zap.String("taskId", taskID))
-		return nil
 	}
 
 	curUnix := helpers.CurrentUTCUnix()

--- a/services/scheduler/scheduler_utils.go
+++ b/services/scheduler/scheduler_utils.go
@@ -57,6 +57,7 @@ func (s *SchedulerService) ScheduleTaskNow(t smodels.TaskModel) {
 	defer s.tasksMu.Unlock()
 	if _, exists := s.tasks[t.ID]; exists {
 		s.logger.Error("Task Is Already Scheduled", zap.String("taskId", t.ID))
+		return
 	}
 
 	executor := executer.NewExecutorService(s.logger, t, s.schedulerRepo, s.slack)
@@ -111,6 +112,10 @@ func (s *SchedulerService) scheduleTaskWithDelay(duration time.Duration, t smode
 // For non-recurring missed tasks it fires immediately; for recurring tasks it
 // calculates the next interval and defers.
 func (s *SchedulerService) scheduleExistingTask(t smodels.TaskModel) {
+	if !t.IsRecurEnabled && t.Status.IsAlreadyExecuted() {
+		s.logger.Info("Non Recurring Task Already Executed, Skipping", zap.String("taskId", t.ID))
+		return
+	}
 	if !t.IsRecurEnabled && t.Recur == 0 {
 		s.logger.Info("Executing Non Recurring Missed Task", zap.String("taskId", t.ID))
 		s.ScheduleTaskNow(t)


### PR DESCRIPTION
[Orphaned Cron Entry on Duplicate Schedule] - scheduler_utils.go ScheduleTaskNow logged a duplicate warning but continued execution, registering a second cron.EntryID for the same task and overwriting the existing map entry. The original entry was orphaned and ran forever until process restart. Added early return after the duplicate check.

[Completed Tasks Re-Executed on Restart] - scheduler_utils.go scheduleExistingTask fired ScheduleTaskNow for any non-recurring task whose start time had passed, without checking whether it had already executed. On service restart this caused completed tasks to re-run silently. Added IsAlreadyExecuted() guard at the top of scheduleExistingTask, consistent with the existing guard in Enable().

[Config Load Errors Silently Ignored] - main.go
Both k.Load() calls in LoadConfig discarded errors with _. A YAML syntax error in the config file caused the app to start with defaults and silently connect to localhost instead of the configured database.
Replaced with explicit log.Fatalf on failure for both default and file config.

[Non-Atomic Enable/Disable Causing Duplicate Scheduling] - scheduler_repo.go, scheduler_service.go Enable and Disable used a read-then-write pattern: GetOne to check current state, then UpdateEnable to flip it. Two concurrent Enable calls could both pass the in-memory check and both call ScheduleTask, creating duplicate cron entries. Changed UpdateEnable to a compare-and-swap by adding the expected current enable state to the MongoDB filter, so the write only proceeds if the document has not already changed. Returns (bool, error) where false means already in desired state. Service layer now uses this bool to skip scheduling instead of the stale pre-read.

[Force-Execute Blocked on Failed Non-Recurring Tasks] - scheduler_service.go ExecuteNow returned early when IsAlreadyExecuted() was true for non-recurring tasks, making it impossible to retry a failed task via the execute endpoint. The endpoint exists to force-run a task regardless of its state, so this guard contradicted its purpose. Removed the IsAlreadyExecuted check; expired-task guard is retained.