### PR TITLE
ci: update workflows for new deployments/ layout and version stamping

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.23.3'
+          go-version: '1.25.0'
           cache: false
 
       - name: Cache
@@ -28,11 +28,13 @@ jobs:
 
       - name: Build
         run: |
-          go build -v ./...
+          GIT_SHA=$(git rev-parse HEAD)
+          BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          go build -ldflags "-X scheduler/internal/version.Version=${GIT_SHA} -X scheduler/internal/version.BuildTime=${BUILD_TIME}" -v ./...
           go vet ./...
 
       - name: Test
         run: go test -v ./...
 
       - name: Lint
-        run:  gofmt -d ./
+        run: gofmt -d ./

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Get Git Commit SHA
-        id: git_sha
-        run: echo "GIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
+      - name: Get Git Commit SHA and Build Time
+        run: |
+          echo "GIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo "BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_ENV
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -30,8 +31,12 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: deployments/Dockerfile
           push: true
           platforms: linux/amd64
+          build-args: |
+            COMMIT=${{ env.GIT_SHA }}
+            BUILD_TIME=${{ env.BUILD_TIME }}
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/scheduler:latest
             ${{ secrets.DOCKER_USERNAME }}/scheduler:${{ env.GIT_SHA }}


### PR DESCRIPTION
- publish.yml: point Dockerfile to deployments/Dockerfile, pass COMMIT and BUILD_TIME build-args so the binary gets a stamped version
- go-lint.yml: bump Go version to 1.25.0 to match go.mod, inject ldflags in the build step so version.Version/BuildTime are set